### PR TITLE
Bugfix: For failed pip installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==6.7
 Flask==1.0.2
 itsdangerous==0.24
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==2.1.1
 numpy==1.15.0
 pandas==0.23.3
 python-dateutil==2.7.3


### PR DESCRIPTION
Installs fine now with this change of MarkupSafe from 1.0 to 2.1.1